### PR TITLE
Runtime panic

### DIFF
--- a/clipboard_linux.go
+++ b/clipboard_linux.go
@@ -21,8 +21,8 @@ var (
 	xselPaste = exec.Command(xsel, "--output", "--clipboard")
 	xselCopy  = exec.Command(xsel, "--input", "--clipboard")
 
-	xclipPaste = exec.Command(xclip, "-out", "-sel", "clipboard")
-	xclipCopy  = exec.Command(xclip, "-in", "-sel", "clipboard")
+	xclipPaste = exec.Command(xclip, "-out", "-selection", "clipboard")
+	xclipCopy  = exec.Command(xclip, "-in", "-selection", "clipboard")
 )
 
 func init() {


### PR DESCRIPTION
The last pull request I made unfortunately introduced a runtime slice index panic if neither xclip nor xsel were present on the client machine. This fixes that and restores the prior behaviour of just letting the *exec.Cmd fail when it attempts to run with an invalid path name.

I've also changed the flags that are presented to xclip because the tests weren't passing on my machine; in fact it looks like the -secondary flag comes from xsel and should have been -selection[0] all along.

[0] http://linux.die.net/man/1/xclip
