### PR TITLE
Fix #6:correct allocation size of WriteAll on Windows

### DIFF
--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -73,7 +73,7 @@ func writeAll(text string) error {
 
 	data := syscall.StringToUTF16(text)
 
-	h, _, err := globalAlloc.Call(gmemFixed, uintptr(len(data)*int(unsafe.Sizeof(data))/8))
+	h, _, err := globalAlloc.Call(gmemFixed, uintptr(len(data)*2*int(unsafe.Sizeof(data)+7)/8))
 	if h == 0 {
 		return err
 	}


### PR DESCRIPTION
I made a patch to fix [issue #6](https://github.com/atotto/clipboard/issues/6).
