### PR TITLE
Fix #6:correct allocation size of WriteAll on Windows(TRY2)

### DIFF
--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -73,7 +73,7 @@ func writeAll(text string) error {
 
 	data := syscall.StringToUTF16(text)
 
-	h, _, err := globalAlloc.Call(gmemFixed, uintptr(len(data)*int(unsafe.Sizeof(data))/8))
+	h, _, err := globalAlloc.Call(gmemFixed, uintptr(len(data)*int(unsafe.Sizeof(data[0]))))
 	if h == 0 {
 		return err
 	}


### PR DESCRIPTION
modify allocation size which was too large.
