### PR TITLE
Make xclip the default clipboard utility on linux

### DIFF
--- a/clipboard_linux.go
+++ b/clipboard_linux.go
@@ -27,19 +27,17 @@ var (
 )
 
 func init() {
-	pasteCmdArgs = xselPasteArgs
-	copyCmdArgs = xselCopyArgs
-
-	_, err := exec.LookPath(xsel)
-	if err == nil {
-		return
-	}
-
 	pasteCmdArgs = xclipPasteArgs
 	copyCmdArgs = xclipCopyArgs
 
-	_, err = exec.LookPath(xclip)
-	if err == nil {
+	if _, err := exec.LookPath(xclip); err == nil {
+		return
+	}
+
+	pasteCmdArgs = xselPasteArgs
+	copyCmdArgs = xselCopyArgs
+
+	if _, err := exec.LookPath(xsel); err == nil {
 		return
 	}
 


### PR DESCRIPTION
I suggest making xclip the default clipboard utility on Linux.

xsel has a bug when it is used to copy/paste large texts (>4KB). I could reproduce these problems on two different Linux installations (one of them is a current Ubuntu Linux 15.04 installation).
Some links to public bug trackers to support this: [debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=758599), [fedora](https://lists.fedoraproject.org/archives/list/scm-commits@lists.fedoraproject.org/thread/OTAX3QVR7CLVANE6XPT225376IKTLMU2/?sort=date), [redhat](https://bugzilla.redhat.com/show_bug.cgi?id=857471#c2)
While patches may exist, it seems that most users have an xsel version with the bug still present.

xclip does not have these problems and worked well over several weeks of testing.