### PR TITLE
Avoid complaints during startup, add Unsupported

### DIFF
--- a/clipboard.go
+++ b/clipboard.go
@@ -16,3 +16,7 @@ func ReadAll() (string, error) {
 func WriteAll(text string) error {
 	return writeAll(text)
 }
+
+// Unsupported might be set true during clipboard init, to help callers decide
+// whether or not to offer clipboard options.
+var Unsupported bool

--- a/clipboard_unix.go
+++ b/clipboard_unix.go
@@ -7,6 +7,7 @@
 package clipboard
 
 import (
+	"errors"
 	"os/exec"
 )
 
@@ -24,6 +25,8 @@ var (
 
 	xclipPasteArgs = []string{xclip, "-out", "-selection", "clipboard"}
 	xclipCopyArgs  = []string{xclip, "-in", "-selection", "clipboard"}
+
+	missingCommands = errors.New("No clipboard utilities available. Please install xsel or xclip.")
 )
 
 func init() {
@@ -41,7 +44,7 @@ func init() {
 		return
 	}
 
-	println("No clipboard utilities available. Please install xsel or xclip.")
+	Unsupported = true
 }
 
 func getPasteCommand() *exec.Cmd {
@@ -53,6 +56,9 @@ func getCopyCommand() *exec.Cmd {
 }
 
 func readAll() (string, error) {
+	if Unsupported {
+		return "", missingCommands
+	}
 	pasteCmd := getPasteCommand()
 	out, err := pasteCmd.Output()
 	if err != nil {
@@ -62,6 +68,9 @@ func readAll() (string, error) {
 }
 
 func writeAll(text string) error {
+	if Unsupported {
+		return missingCommands
+	}
 	copyCmd := getCopyCommand()
 	in, err := copyCmd.StdinPipe()
 	if err != nil {


### PR DESCRIPTION
If a program using this library doesn't have clipboard manipulation as
its main feature (just a useful extra), this library always complaining
to stderr during init, where it can't be stopped, makes those programs
verbose during startup on systems where there is no clipboard (eg,
headless servers).

Rather than complain to stdio in a library, move the complaint into an
error return to make it clearer what's going wrong.

In addition, export a package variable `Unsupported` which client
programs might use to inhibit use of the clipboard functions, for
smoother integration.