### PR TITLE
On linux provide global var Primary which allow to choose primary mode

### DIFF
--- a/clipboard_unix.go
+++ b/clipboard_unix.go
@@ -17,6 +17,8 @@ const (
 )
 
 var (
+	Primary bool
+
 	pasteCmdArgs []string
 	copyCmdArgs  []string
 
@@ -48,10 +50,16 @@ func init() {
 }
 
 func getPasteCommand() *exec.Cmd {
+	if Primary {
+		pasteCmdArgs = pasteCmdArgs[:1]
+	}
 	return exec.Command(pasteCmdArgs[0], pasteCmdArgs[1:]...)
 }
 
 func getCopyCommand() *exec.Cmd {
+	if Primary {
+		copyCmdArgs = copyCmdArgs[:1]
+	}
 	return exec.Command(copyCmdArgs[0], copyCmdArgs[1:]...)
 }
 


### PR DESCRIPTION
Issue #17 Add middle click paste support on linux.
In clipboard_unix.go (which compiled ander linux only) provide global var Primary bool. Setting it true will make xclip and xsel use Xserver's default primary selection mode just by not providing additional -selection args xsel(1) xclip(1). Otherwise clipboard mode will be used.