### PR TITLE
Fix build tag to support DragonFlyBSD

### DIFF
--- a/clipboard_unix.go
+++ b/clipboard_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build freebsd linux netbsd openbsd solaris
+// +build freebsd linux netbsd openbsd solaris dragonfly
 
 package clipboard
 


### PR DESCRIPTION
DragonFly was missing as a unix variant.