### PR TITLE
Windows clipboard fixes

### DIFF
--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -40,7 +40,7 @@ func readAll() (string, error) {
 	defer closeClipboard.Call()
 
 	h, _, err := getClipboardData.Call(cfUnicodetext)
-	if r == 0 {
+	if h == 0 {
 		return "", err
 	}
 

--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -94,6 +94,11 @@ func writeAll(text string) error {
 	if h == 0 {
 		return err
 	}
+	defer func() {
+		if h != 0 {
+			globalFree.Call(h)
+		}
+	}()
 
 	l, _, err := globalLock.Call(h)
 	if l == 0 {
@@ -114,5 +119,6 @@ func writeAll(text string) error {
 	if r == 0 {
 		return err
 	}
+	h = 0 // suppress deferred cleanup
 	return nil
 }


### PR DESCRIPTION
This PR addresses the following issues with the Windows implementation:

1. OpenClipboard fails with an access denied error if the clipboard is busy. (I found this was visible in testing.)
2. The memory for the clipboard data was not freed on error. This is issue 11.
3. The API documentation requires that the clipboard data be stored in moveable memory.
