### PR TITLE
Add Termux support

### DIFF
--- a/clipboard_unix.go
+++ b/clipboard_unix.go
@@ -12,8 +12,10 @@ import (
 )
 
 const (
-	xsel  = "xsel"
-	xclip = "xclip"
+	xsel               = "xsel"
+	xclip              = "xclip"
+	termuxClipboardGet = "termux-clipboard-get"
+	termuxClipboardSet = "termux-clipboard-set"
 )
 
 var (
@@ -28,7 +30,10 @@ var (
 	xclipPasteArgs = []string{xclip, "-out", "-selection", "clipboard"}
 	xclipCopyArgs  = []string{xclip, "-in", "-selection", "clipboard"}
 
-	missingCommands = errors.New("No clipboard utilities available. Please install xsel or xclip.")
+	termuxPasteArgs = []string{termuxClipboardGet}
+	termuxCopyArgs  = []string{termuxClipboardSet}
+
+	missingCommands = errors.New("No clipboard utilities available. Please install xsel, xclip, or Termux:API add-on for termux-clipboard-get/set.")
 )
 
 func init() {
@@ -44,6 +49,15 @@ func init() {
 
 	if _, err := exec.LookPath(xsel); err == nil {
 		return
+	}
+
+	pasteCmdArgs = termuxPasteArgs
+	copyCmdArgs = termuxCopyArgs
+
+	if _, err := exec.LookPath(termuxClipboardSet); err == nil {
+		if _, err := exec.LookPath(termuxClipboardGet); err == nil {
+			return
+		}
 	}
 
 	Unsupported = true


### PR DESCRIPTION
This patch adds [Termux](https://termux.com/) (Android terminal emulator/Linux environment app) support to Clipboard for Go.

Termux doesn’t support xsel or xclip but it does have its own command-line utilities for getting and setting the system clipboard in the [Termux:API add-on](https://termux.com/add-on-api.html).

This patch makes Clipboard for Go use the _termux_clipboard_get_ command for paste and _termux_clipboard_set_ command for copy if those commands exist in an executable state on the system.