### PR TITLE
Add wl-clipboard support on *nix

### DIFF
--- a/clipboard_unix.go
+++ b/clipboard_unix.go
@@ -8,12 +8,15 @@ package clipboard
 
 import (
 	"errors"
+	"os"
 	"os/exec"
 )
 
 const (
 	xsel               = "xsel"
 	xclip              = "xclip"
+	wlcopy = "wl-copy"
+	wlpaste = "wl-paste"
 	termuxClipboardGet = "termux-clipboard-get"
 	termuxClipboardSet = "termux-clipboard-set"
 )
@@ -30,13 +33,27 @@ var (
 	xclipPasteArgs = []string{xclip, "-out", "-selection", "clipboard"}
 	xclipCopyArgs  = []string{xclip, "-in", "-selection", "clipboard"}
 
+	wlpasteArgs = []string{wlpaste, "--no-newline"}
+	wlcopyArgs = []string{wlcopy}
+
 	termuxPasteArgs = []string{termuxClipboardGet}
 	termuxCopyArgs  = []string{termuxClipboardSet}
 
-	missingCommands = errors.New("No clipboard utilities available. Please install xsel, xclip, or Termux:API add-on for termux-clipboard-get/set.")
+	missingCommands = errors.New("No clipboard utilities available. Please install xsel, xclip, wl-clipboard or Termux:API add-on for termux-clipboard-get/set.")
 )
 
 func init() {
+	if os.Getenv("WAYLAND_DISPLAY") != "" {
+		pasteCmdArgs = wlpasteArgs;
+		copyCmdArgs = wlcopyArgs;
+
+		if _, err := exec.LookPath(wlcopy); err == nil {
+			if _, err := exec.LookPath(wlpaste); err == nil {
+				return
+			}
+		}
+	}
+
 	pasteCmdArgs = xclipPasteArgs
 	copyCmdArgs = xclipCopyArgs
 


### PR DESCRIPTION
On *nix, clipboard is managed by graphical stack. There are two main
players out there: X.org server and Wayland. Despite running XWayland
proxy, dealing with X.org clipbiard is a pain because there are bunch of
corner cases when it does not work fine. Thus, we need a better solution
than simply using xclip/xsel tools. Luckily there is wl-clipboard [1]
project that solves this issue by providing wl-copy/wl-paste command
lines tools. This project is already packaged for popular Linux
distributives (such as Arch [2], Ubuntu [3] and Debian [4]). So this
commit adds support for wl-clipboard if Wayland session is detected.

Please note, there's a way to fallback to xclip/xsel because they work
somehow on Wayland anyway.

[1] https://github.com/bugaevc/wl-clipboard
[2] https://www.archlinux.org/packages/community/x86_64/wl-clipboard/
[3] https://packages.ubuntu.com/search?keywords=wl-clipboard
[4] https://packages.debian.org/search?keywords=wl-clipboard