### PR TITLE
gocopy: erase clipboard after timeout (-t flag)

### DIFF
--- a/cmd/gocopy/gocopy.go
+++ b/cmd/gocopy/gocopy.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"flag"
 	"io/ioutil"
 	"os"
+	"time"
 
 	"github.com/atotto/clipboard"
 )
 
 func main() {
+	timeout := flag.Duration("t", 0, "Erase clipboard after timeout.  Durations are specified like \"20s\" or \"2h45m\".  0 (default) means never erase.")
+	flag.Parse()
 
 	out, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
@@ -16,5 +20,19 @@ func main() {
 
 	if err := clipboard.WriteAll(string(out)); err != nil {
 		panic(err)
+	}
+
+	if timeout != nil && *timeout > 0 {
+		<-time.After(*timeout)
+		text, err := clipboard.ReadAll()
+		if err != nil {
+			os.Exit(1)
+		}
+		if text == string(out) {
+			err = clipboard.WriteAll("")
+		}
+	}
+	if err != nil {
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This change adds a flag (-t <duration>), and have gocopy clear the clipboard after that period of time.

I realize that the point of gocopy may be to be as simple as possible.  So I'm not offended if you're not interested in this.  I just wanted a simple tool for this purpose, and sharing it back here.

Thanks for contributing this library.
