### PR TITLE
Fix deadlock on windows

### DIFF
--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -18,12 +18,13 @@ const (
 )
 
 var (
-	user32           = syscall.MustLoadDLL("user32")
-	openClipboard    = user32.MustFindProc("OpenClipboard")
-	closeClipboard   = user32.MustFindProc("CloseClipboard")
-	emptyClipboard   = user32.MustFindProc("EmptyClipboard")
-	getClipboardData = user32.MustFindProc("GetClipboardData")
-	setClipboardData = user32.MustFindProc("SetClipboardData")
+	user32                     = syscall.MustLoadDLL("user32")
+	isClipboardFormatAvailable = user32.MustFindProc("IsClipboardFormatAvailable")
+	openClipboard              = user32.MustFindProc("OpenClipboard")
+	closeClipboard             = user32.MustFindProc("CloseClipboard")
+	emptyClipboard             = user32.MustFindProc("EmptyClipboard")
+	getClipboardData           = user32.MustFindProc("GetClipboardData")
+	setClipboardData           = user32.MustFindProc("SetClipboardData")
 
 	kernel32     = syscall.NewLazyDLL("kernel32")
 	globalAlloc  = kernel32.NewProc("GlobalAlloc")
@@ -50,6 +51,9 @@ func waitOpenClipboard() error {
 }
 
 func readAll() (string, error) {
+	if formatAvailable, _, err := isClipboardFormatAvailable.Call(cfUnicodetext); formatAvailable == 0 {
+		return "", err
+	}
 	err := waitOpenClipboard()
 	if err != nil {
 		return "", err

--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -7,6 +7,7 @@
 package clipboard
 
 import (
+	"runtime"
 	"syscall"
 	"time"
 	"unsafe"
@@ -51,6 +52,10 @@ func waitOpenClipboard() error {
 }
 
 func readAll() (string, error) {
+	// LockOSThread ensure that the whole method will keep executing on the same thread from begin to end (it actually locks the goroutine thread attribution).
+	// Otherwise if the goroutine switch thread during execution (which is a common practice), the OpenClipboard and CloseClipboard will happen on two different threads, and it will result in a clipboard deadlock.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	if formatAvailable, _, err := isClipboardFormatAvailable.Call(cfUnicodetext); formatAvailable == 0 {
 		return "", err
 	}


### PR DESCRIPTION
In MSDN the clipboard API documentation state that, the `OpenClipboard()` and `CloseClipboard()` must come from the **same thread**.

By design goroutines jumps from one thread to another and this is causing an issue on windows. It sometimes results in a clipboard deadlocked at the system wide level, because of the thread who lock is not the one which tryies to unlock.

The introduction of `runtime.LockOSThread()` instuct the goroutine to stick to his current thread no matter what, until  `runtime.UnlockOSThread()` is called.