### PR TITLE
Provide meaningful error message when clipboard format is unavailble

### DIFF
--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -34,6 +34,8 @@ var (
 	globalLock   = kernel32.NewProc("GlobalLock")
 	globalUnlock = kernel32.NewProc("GlobalUnlock")
 	lstrcpy      = kernel32.NewProc("lstrcpyW")
+
+	ErrFormatUnavailable = errors.New("clipboard format is unavailable")
 )
 
 // waitOpenClipboard opens the clipboard, waiting for up to a second to do so.
@@ -58,7 +60,7 @@ func readAll() (string, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	if formatAvailable, _, _ := isClipboardFormatAvailable.Call(cfUnicodetext); formatAvailable == 0 {
-		return "", errors.New("clipboard format is unavailable")
+		return "", ErrFormatUnavailable
 	}
 	err := waitOpenClipboard()
 	if err != nil {

--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -7,6 +7,7 @@
 package clipboard
 
 import (
+	"errors"
 	"runtime"
 	"syscall"
 	"time"
@@ -56,8 +57,8 @@ func readAll() (string, error) {
 	// Otherwise if the goroutine switch thread during execution (which is a common practice), the OpenClipboard and CloseClipboard will happen on two different threads, and it will result in a clipboard deadlock.
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
-	if formatAvailable, _, err := isClipboardFormatAvailable.Call(cfUnicodetext); formatAvailable == 0 {
-		return "", err
+	if formatAvailable, _, _ := isClipboardFormatAvailable.Call(cfUnicodetext); formatAvailable == 0 {
+		return "", errors.New("clipboard format is unavailable")
 	}
 	err := waitOpenClipboard()
 	if err != nil {


### PR DESCRIPTION
When `isClipboardFormatAvailable.Call(...)` fails, the error `operation completed successfully` is returned.  This happens because of the way calls to the Win32 API handles successes/errors.

This PR provides the user of this package more context into what when wrong.