### PR TITLE
fix: Windows Subsystem for Linux support

### DIFF
--- a/clipboard_unix.go
+++ b/clipboard_unix.go
@@ -60,6 +60,18 @@ func init() {
 		}
 	}
 
+	if os.Getenv("WSL_DISTRO_NAME") != "" {
+		pasteCmdArgs = powershellExePasteArgs
+		copyCmdArgs = clipExeCopyArgs
+		trimDos = true
+
+		if _, err := exec.LookPath(clipExe); err == nil {
+			if _, err := exec.LookPath(powershellExe); err == nil {
+				return
+			}
+		}
+	}
+
 	pasteCmdArgs = xclipPasteArgs
 	copyCmdArgs = xclipCopyArgs
 
@@ -79,16 +91,6 @@ func init() {
 
 	if _, err := exec.LookPath(termuxClipboardSet); err == nil {
 		if _, err := exec.LookPath(termuxClipboardGet); err == nil {
-			return
-		}
-	}
-
-	pasteCmdArgs = powershellExePasteArgs
-	copyCmdArgs = clipExeCopyArgs
-	trimDos = true
-
-	if _, err := exec.LookPath(clipExe); err == nil {
-		if _, err := exec.LookPath(powershellExe); err == nil {
 			return
 		}
 	}


### PR DESCRIPTION
If the WSL distro has xclip and xsel installed by default, clip.exe won't be used.

close #45 
also related to #42 
(and also I came from https://github.com/derailed/k9s/issues/868)