### PR TITLE
Prepare a command to use PRIMARY in wayland

### DIFF
--- a/clipboard_unix.go
+++ b/clipboard_unix.go
@@ -30,17 +30,29 @@ var (
 	pasteCmdArgs []string
 	copyCmdArgs  []string
 
+	pastePrimaryCmdArgs []string
+	copyPrimaryCmdArgs  []string
+
 	xselPasteArgs = []string{xsel, "--output", "--clipboard"}
 	xselCopyArgs  = []string{xsel, "--input", "--clipboard"}
 
+	xselPrimaryPasteArgs = []string{xsel, "--output", "--primary"}
+	xselPrimaryCopyArgs  = []string{xsel, "--input", "--primary"}
+
 	xclipPasteArgs = []string{xclip, "-out", "-selection", "clipboard"}
 	xclipCopyArgs  = []string{xclip, "-in", "-selection", "clipboard"}
+
+	xclipPrimaryPasteArgs = []string{xclip, "-out", "-selection", "primary"}
+	xclipPrimaryCopyArgs  = []string{xclip, "-in", "-selection", "primary"}
 
 	powershellExePasteArgs = []string{powershellExe, "Get-Clipboard"}
 	clipExeCopyArgs        = []string{clipExe}
 
 	wlpasteArgs = []string{wlpaste, "--no-newline"}
 	wlcopyArgs  = []string{wlcopy}
+
+	wlPrimarypasteArgs = []string{wlpaste, "--no-newline", "--primary"}
+	wlPrimarycopyArgs  = []string{wlcopy, "--primary"}
 
 	termuxPasteArgs = []string{termuxClipboardGet}
 	termuxCopyArgs  = []string{termuxClipboardSet}
@@ -52,6 +64,8 @@ func init() {
 	if os.Getenv("WAYLAND_DISPLAY") != "" {
 		pasteCmdArgs = wlpasteArgs
 		copyCmdArgs = wlcopyArgs
+		pastePrimaryCmdArgs = wlPrimarypasteArgs
+		copyPrimaryCmdArgs = wlPrimarycopyArgs
 
 		if _, err := exec.LookPath(wlcopy); err == nil {
 			if _, err := exec.LookPath(wlpaste); err == nil {
@@ -62,6 +76,8 @@ func init() {
 
 	pasteCmdArgs = xclipPasteArgs
 	copyCmdArgs = xclipCopyArgs
+	pastePrimaryCmdArgs = xclipPrimaryPasteArgs
+	copyPrimaryCmdArgs = xclipPrimaryCopyArgs
 
 	if _, err := exec.LookPath(xclip); err == nil {
 		return
@@ -69,6 +85,8 @@ func init() {
 
 	pasteCmdArgs = xselPasteArgs
 	copyCmdArgs = xselCopyArgs
+	pastePrimaryCmdArgs = xselPrimaryPasteArgs
+	copyPrimaryCmdArgs = xselPrimaryCopyArgs
 
 	if _, err := exec.LookPath(xsel); err == nil {
 		return
@@ -76,6 +94,8 @@ func init() {
 
 	pasteCmdArgs = termuxPasteArgs
 	copyCmdArgs = termuxCopyArgs
+	pastePrimaryCmdArgs = termuxPasteArgs
+	copyPrimaryCmdArgs = termuxCopyArgs
 
 	if _, err := exec.LookPath(termuxClipboardSet); err == nil {
 		if _, err := exec.LookPath(termuxClipboardGet); err == nil {
@@ -85,6 +105,8 @@ func init() {
 
 	pasteCmdArgs = powershellExePasteArgs
 	copyCmdArgs = clipExeCopyArgs
+	pastePrimaryCmdArgs = powershellExePasteArgs
+	copyPrimaryCmdArgs = clipExeCopyArgs
 	trimDos = true
 
 	if _, err := exec.LookPath(clipExe); err == nil {
@@ -98,14 +120,14 @@ func init() {
 
 func getPasteCommand() *exec.Cmd {
 	if Primary {
-		pasteCmdArgs = pasteCmdArgs[:1]
+		return exec.Command(pastePrimaryCmdArgs[0], pastePrimaryCmdArgs[1:]...)
 	}
 	return exec.Command(pasteCmdArgs[0], pasteCmdArgs[1:]...)
 }
 
 func getCopyCommand() *exec.Cmd {
 	if Primary {
-		copyCmdArgs = copyCmdArgs[:1]
+		return exec.Command(copyPrimaryCmdArgs[0], copyPrimaryCmdArgs[1:]...)
 	}
 	return exec.Command(copyCmdArgs[0], copyCmdArgs[1:]...)
 }


### PR DESCRIPTION
Wayland defaults to the clipboard,
so users will need to add an argument if they want to use PRIMARY.
PRIMARY is provided as a separate command, so
that the order of the arguments doesn't matter.