### PR TITLE
added aix build tag to allow compiling on AIX systems

### DIFF
--- a/clipboard_unix.go
+++ b/clipboard_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build freebsd linux netbsd openbsd solaris dragonfly
+// +build freebsd linux netbsd openbsd solaris dragonfly aix
 
 package clipboard
 


### PR DESCRIPTION
Simply added the aix tag to the build instructions to allow 
`go build`
to compile on aix.
Tested on AIX 7.2 / power 8
