### PR TITLE
Enable building on AIX

### DIFF
--- a/clipboard_unix.go
+++ b/clipboard_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build freebsd linux netbsd openbsd solaris dragonfly
+// +build aix freebsd linux netbsd openbsd solaris dragonfly
 
 package clipboard
 


### PR DESCRIPTION
This PR enables building of atotto/clipboard on AIX.

Refs https://github.com/twpayne/chezmoi/issues/2787.