### PR TITLE
fix sporadic failures to load DLLs by lazy loading them

### DIFF
--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -11,6 +11,8 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -19,15 +21,15 @@ const (
 )
 
 var (
-	user32                     = syscall.MustLoadDLL("user32")
-	isClipboardFormatAvailable = user32.MustFindProc("IsClipboardFormatAvailable")
-	openClipboard              = user32.MustFindProc("OpenClipboard")
-	closeClipboard             = user32.MustFindProc("CloseClipboard")
-	emptyClipboard             = user32.MustFindProc("EmptyClipboard")
-	getClipboardData           = user32.MustFindProc("GetClipboardData")
-	setClipboardData           = user32.MustFindProc("SetClipboardData")
+	user32                     = windows.NewLazySystemDLL("user32.dll")
+	isClipboardFormatAvailable = user32.NewProc("IsClipboardFormatAvailable")
+	openClipboard              = user32.NewProc("OpenClipboard")
+	closeClipboard             = user32.NewProc("CloseClipboard")
+	emptyClipboard             = user32.NewProc("EmptyClipboard")
+	getClipboardData           = user32.NewProc("GetClipboardData")
+	setClipboardData           = user32.NewProc("SetClipboardData")
 
-	kernel32     = syscall.NewLazyDLL("kernel32")
+	kernel32     = windows.NewLazySystemDLL("kernel32")
 	globalAlloc  = kernel32.NewProc("GlobalAlloc")
 	globalFree   = kernel32.NewProc("GlobalFree")
 	globalLock   = kernel32.NewProc("GlobalLock")


### PR DESCRIPTION
On Windows DLL loading sometimes fails for spurious reasons.  The panic is always in the following form:

```
syscall.MustLoadDLL(...)
	/opt/hostedtoolcache/go/1.21.1/x64/src/syscall/dll_windows.go:94
github.com/atotto/clipboard.init()
	/home/runner/go/pkg/mod/github.com/atotto/clipboard@v0.1.4/clipboard_windows.go:22 +0x347
```

This appears to be happening while loading the application, and was a frequent issue in CI tests in github.com/pulumi/pulumi. We can fix this by lazy loading the DLLs instead.  We've been using this fix in our `go.mod`, using a `replace` statement (see https://github.com/pulumi/pulumi/pull/17410), but would love to get this upstreamed, so we can remove that `replace`, and hopefully it helps others as well.