### PR TITLE
feat: add osc52 support

### DIFF
--- a/clipboard.go
+++ b/clipboard.go
@@ -5,6 +5,10 @@
 // Package clipboard read/write on clipboard
 package clipboard
 
+import "os"
+
+var isSsh = os.Getenv("SSH_TTY") != ""
+
 // ReadAll read string from clipboard
 func ReadAll() (string, error) {
 	return readAll()
@@ -12,6 +16,9 @@ func ReadAll() (string, error) {
 
 // WriteAll write string to clipboard
 func WriteAll(text string) error {
+	if isSsh {
+		return writeOsc52(text)
+	}
 	return writeAll(text)
 }
 

--- a/osc52.go
+++ b/osc52.go
@@ -1,0 +1,8 @@
+package clipboard
+
+import "os"
+
+func writeOsc52(text string) error {
+	_, err := os.Stderr.WriteString("\033]52;c;" + text + "\a")
+	return err
+}


### PR DESCRIPTION
This adds support for writing to clipboard via OSC52 only if an SSH session is active. Read support, if supported, is often blocked by terminals or prompted for security reasons. This PR only adds write support for simplicity. Read support, though more complicated, can be added in a separate PR since it requires reading the terminal for response in an asynchronous manner which can also affect TUI applications using this library.