### PR TITLE
fix: defer clipboard command detection to first use

### DIFF
--- a/clipboard_unix.go
+++ b/clipboard_unix.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"sync"
 )
 
 const (
@@ -48,7 +49,15 @@ var (
 	missingCommands = errors.New("No clipboard utilities available. Please install xsel, xclip, wl-clipboard or Termux:API add-on for termux-clipboard-get/set.")
 )
 
-func init() {
+var initOnce sync.Once
+
+func initCommands() {
+	initOnce.Do(func() {
+		detectCommands()
+	})
+}
+
+func detectCommands() {
 	if os.Getenv("WAYLAND_DISPLAY") != "" {
 		pasteCmdArgs = wlpasteArgs
 		copyCmdArgs = wlcopyArgs
@@ -111,6 +120,7 @@ func getCopyCommand() *exec.Cmd {
 }
 
 func readAll() (string, error) {
+	initCommands()
 	if Unsupported {
 		return "", missingCommands
 	}
@@ -127,6 +137,7 @@ func readAll() (string, error) {
 }
 
 func writeAll(text string) error {
+	initCommands()
 	if Unsupported {
 		return missingCommands
 	}


### PR DESCRIPTION
Fixes #63

## Problem

The `init()` function in `clipboard_unix.go` scans `$PATH` for clipboard tools (`xclip`, `xsel`, `wl-copy`, `wl-paste`, `termux-clipboard-set`, `clip.exe`, etc.) at import time. This triggers security tool alerts for programs that import the clipboard package but may not immediately use it.

## Fix

Replace `init()` with lazy initialization via `sync.Once`. The PATH scanning is deferred until the first call to `readAll()` or `writeAll()`.

```go
// Before: scans PATH at import time
func init() { ... }

// After: scans PATH on first clipboard operation
var initOnce sync.Once
func initCommands() { initOnce.Do(detectCommands) }
func readAll()  { initCommands(); ... }
func writeAll() { initCommands(); ... }
```

This is fully backward compatible — the behavior is identical, just deferred.