### PR TITLE
fix(gocopy): handle timeout clipboard clear errors

### DIFF
--- a/cmd/gocopy/gocopy.go
+++ b/cmd/gocopy/gocopy.go
@@ -29,10 +29,9 @@ func main() {
 			os.Exit(1)
 		}
 		if text == string(out) {
-			err = clipboard.WriteAll("")
+			if err := clipboard.WriteAll(""); err != nil {
+				os.Exit(1)
+			}
 		}
-	}
-	if err != nil {
-		os.Exit(1)
 	}
 }


### PR DESCRIPTION
There's a code path in `gocopy` where the error from `err = clipboard.WriteAll("")` is unhandled and the wrong exit code is disseminated. 

The outer/lower `err != nil` is looking at an `err` in a different scope than the clipboard clear (declared at `clipboard.RealAll()`).

Found by LLM, but understood and reviewed by me.