### PR TITLE
feat: add Clear() for reliable empty clipboard on Windows

### DIFF
--- a/clipboard.go
+++ b/clipboard.go
@@ -15,6 +15,13 @@ func WriteAll(text string) error {
 	return writeAll(text)
 }
 
+// Clear empties the clipboard without writing a placeholder value.
+// On Windows, writing an empty string via WriteAll can leave the clipboard
+// in a bad state for subsequent reads; Clear uses EmptyClipboard instead (#68).
+func Clear() error {
+	return clearAll()
+}
+
 // Unsupported might be set true during clipboard init, to help callers decide
 // whether or not to offer clipboard options.
 var Unsupported bool

--- a/clipboard_darwin.go
+++ b/clipboard_darwin.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build darwin
 // +build darwin
 
 package clipboard
@@ -49,4 +50,7 @@ func writeAll(text string) error {
 		return err
 	}
 	return copyCmd.Wait()
+}
+func clearAll() error {
+	return writeAll("")
 }

--- a/clipboard_plan9.go
+++ b/clipboard_plan9.go
@@ -2,13 +2,14 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build plan9
 // +build plan9
 
 package clipboard
 
 import (
-	"os"
 	"io/ioutil"
+	"os"
 )
 
 func readAll() (string, error) {
@@ -22,7 +23,7 @@ func readAll() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	
+
 	return string(str), nil
 }
 
@@ -32,11 +33,14 @@ func writeAll(text string) error {
 		return err
 	}
 	defer f.Close()
-	
+
 	_, err = f.Write([]byte(text))
 	if err != nil {
 		return err
 	}
-	
+
 	return nil
+}
+func clearAll() error {
+	return writeAll("")
 }

--- a/clipboard_unix.go
+++ b/clipboard_unix.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build freebsd || linux || netbsd || openbsd || solaris || dragonfly
 // +build freebsd linux netbsd openbsd solaris dragonfly
 
 package clipboard
@@ -146,4 +147,7 @@ func writeAll(text string) error {
 		return err
 	}
 	return copyCmd.Wait()
+}
+func clearAll() error {
+	return writeAll("")
 }

--- a/clipboard_windows.go
+++ b/clipboard_windows.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package clipboard
@@ -151,6 +152,23 @@ func writeAll(text string) error {
 	h = 0 // suppress deferred cleanup
 	closed, _, err := closeClipboard.Call()
 	if closed == 0 {
+		return err
+	}
+	return nil
+}
+
+func clearAll() error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	err := waitOpenClipboard()
+	if err != nil {
+		return err
+	}
+
+	r, _, err := emptyClipboard.Call(0)
+	_, _, _ = closeClipboard.Call()
+	if r == 0 {
 		return err
 	}
 	return nil


### PR DESCRIPTION
## Summary

On Windows, repeatedly reading then clearing the clipboard via `WriteAll("")` can fail subsequent reads (#68).

## Fix

Add `clipboard.Clear()` which uses `EmptyClipboard` on Windows (and empty-write on other platforms). Document that callers who need a true empty clipboard should prefer `Clear()` over `WriteAll("")`.

Fixes #68
